### PR TITLE
Untrack kicad files from lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,3 @@
 *.stl filter=lfs diff=lfs merge=lfs -text
 *.step filter=lfs diff=lfs merge=lfs -text
 *.FCStd* filter=lfs diff=lfs merge=lfs -text
-# Schematics (KiCad)
-*.kicad_pcb filter=lfs diff=lfs merge=lfs -text
-*.kicad_pcb filter=lfs diff=lfs merge=lfs -text
-*.sch filter=lfs diff=lfs merge=lfs -text
-*.kicad_mod filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Tracking KiCad files with git LFS has only been a source of pain with no real benefits so I'll untrack all KiCad related files and restore their contents to the repository.